### PR TITLE
Comment out non-bmp parts (mostly kanji)

### DIFF
--- a/flowdock-text.js
+++ b/flowdock-text.js
@@ -139,11 +139,11 @@ if (typeof FlowdockText === "undefined" || FlowdockText === null) {
   addCharsToCharClass(nonLatinHashtagChars, 0x3099, 0x309E); // Hiragana voicing and iteration mark
   addCharsToCharClass(nonLatinHashtagChars, 0x3400, 0x4DBF); // Kanji (CJK Extension A)
   addCharsToCharClass(nonLatinHashtagChars, 0x4E00, 0x9FFF); // Kanji (Unified)
-  // -- Disabled as it breaks the Regex.
+  // -- Disabled as it breaks the Regex - Ecmascript doesn't support non-BMP (Unicode Basic Multilingual Plane) characters
   //addCharsToCharClass(nonLatinHashtagChars, 0x20000, 0x2A6DF); // Kanji (CJK Extension B)
-  addCharsToCharClass(nonLatinHashtagChars, 0x2A700, 0x2B73F); // Kanji (CJK Extension C)
-  addCharsToCharClass(nonLatinHashtagChars, 0x2B740, 0x2B81F); // Kanji (CJK Extension D)
-  addCharsToCharClass(nonLatinHashtagChars, 0x2F800, 0x2FA1F); // Kanji (CJK supplement)
+  //addCharsToCharClass(nonLatinHashtagChars, 0x2A700, 0x2B73F); // Kanji (CJK Extension C)
+  //addCharsToCharClass(nonLatinHashtagChars, 0x2B740, 0x2B81F); // Kanji (CJK Extension D)
+  //addCharsToCharClass(nonLatinHashtagChars, 0x2F800, 0x2FA1F); // Kanji (CJK supplement)
   addCharsToCharClass(nonLatinHashtagChars, 0x3003, 0x3003); // Kanji iteration mark
   addCharsToCharClass(nonLatinHashtagChars, 0x3005, 0x3005); // Kanji iteration mark
   addCharsToCharClass(nonLatinHashtagChars, 0x303B, 0x303B); // Han iteration mark


### PR DESCRIPTION
``` js
>>> String.fromCharCode(0x2FA1F).charCodeAt(0)
64031
>>> 0x2fa1f
195103
>>> 195103 & 0xffff
64031
```
