### PR TITLE
Additional scripts for hashtags

### DIFF
--- a/flowdock-text.js
+++ b/flowdock-text.js
@@ -153,8 +153,13 @@ if (typeof FlowdockText === "undefined" || FlowdockText === null) {
   addCharsToCharClass(nonLatinHashtagChars, 0x303B, 0x303B); // Han iteration mark
 
   FlowdockText.regexen.nonLatinHashtagChars = regexSupplant(nonLatinHashtagChars.join(""));
+
+  var latinAccentChars = [];
+  addCharsToCharClass(latinAccentChars, 0x00C0, 0x00FF); // Latin-1 Supplement
+  addCharsToCharClass(latinAccentChars, 0x0100, 0x017F); // Latin Extended A
+  addCharsToCharClass(latinAccentChars, 0x1E00, 0x1EFF); // Latin Extended Additional
   // Latin accented characters (subtracted 0xD7 from the range, it's a confusable multiplication sign. Looks like "x")
-  FlowdockText.regexen.latinAccentChars = regexSupplant("ÀÁÂÃÄÅÆÇÈÉÊËĞÌÍÎÏİÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëğìíîïıðñòóôõöøùúûüýþş\\303\\277");
+  FlowdockText.regexen.latinAccentChars = regexSupplant(latinAccentChars.join(""));
 
   FlowdockText.regexen.endScreenNameMatch = regexSupplant(/^(?:#{atSigns}|[#{latinAccentChars}]|:\/\/)/);
 

--- a/test/conformance_tests/extract.yml
+++ b/test/conformance_tests/extract.yml
@@ -724,6 +724,10 @@ tests:
       text: "Getting my Oktoberfest on #münchen"
       expected: ["münchen"]
 
+    - description: "Extract a hashtag containing ğ"
+      text: "in Turkish #dağ is a mountain"
+      expected: ["dağ"]
+
     - description: "DO NOT Extract a hashtag containing Japanese"
       text: "this is not valid: # 会議中 ハッシュ"
       expected: []


### PR DESCRIPTION
Include extended Latin characters and Greek alphabet into allowed hashtag characters. Turkish, Vietnamese and other scripts are now supported.

The character ranges are as defined in [Unicode 6.3](http://www.unicode.org/versions/Unicode6.3.0/ch07.pdf). Latin Extended-B characters are not included as they are mostly rarely used digraphs.
