### PR TITLE
Add @-signs to hashtag-boundary

### DIFF
--- a/flowdock-text.js
+++ b/flowdock-text.js
@@ -169,7 +169,7 @@ if (typeof FlowdockText === "undefined" || FlowdockText === null) {
   FlowdockText.regexen.usernameAlphaNumericEnd = regexSupplant(/[a-z0-9_\-#{latinAccentChars}#{nonLatinHashtagChars}]/i);
   FlowdockText.regexen.hashtagAlphaNumeric = regexSupplant(/[a-z0-9_\-#{latinAccentChars}#{nonLatinHashtagChars}]/i);
   FlowdockText.regexen.endHashtagMatch = /^(?:[#＃]|:\/\/)/;
-  FlowdockText.regexen.hashtagBoundary = regexSupplant(/(?:^|$|[^&\/a-z0-9_#{latinAccentChars}#{nonLatinHashtagChars}])/);
+  FlowdockText.regexen.hashtagBoundary = regexSupplant(/(?:^|$|[^&\/a-z0-9_#{atSigns}#{latinAccentChars}#{nonLatinHashtagChars}])/);
   FlowdockText.regexen.singleValidHashTag = regexSupplant(/^#{hashtagAlphaNumeric}+$/i);
   // FlowdockText change: allow all-numeric hashtags
   FlowdockText.regexen.autoLinkHashtags = regexSupplant(/(#{hashtagBoundary})(#|＃)(#{hashtagAlphaNumeric}+)/gi);


### PR DESCRIPTION
This will prevent multiple parsing of @mentions (so that things without @ don't match). Hashtags already exclude @-signs by only including latin letters plus a bunch of other chars. hashtagBoundary is used elsewhere to match for example highlights without @-sign, so this will help there. No existing specs fail after this modification.
